### PR TITLE
fix: do not create model and remote methods if they already exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,19 @@ const debug = require('debug')('loopback:component:templates')
 const Promise = require('bluebird')
 
 /**
+ * Helper method to check if a remote method exists on a model
+ * @param model The LoopBack Model
+ * @param methodName The name of the Remote Method
+ * @returns {boolean}
+ */
+function hasRemoteMethod(model, methodName) {
+  return model.sharedClass
+    .methods({ includeDisabled: false })
+    .map(sharedMethod => sharedMethod.name)
+    .includes(methodName)
+}
+
+/**
  * Add remote methods for each template.
  *
  * @param {Object} app loopback application
@@ -23,6 +36,18 @@ function addRemoteMethods(app) {
       const fnName = `_template_${templateName}`
       const fnNameRemote = `_template_${templateName}_remote`
       const path = `/${fnName}`
+
+      // Don't add the method if it already exists on the model
+      if (typeof Model[fnName] === 'function') {
+        debug('Method already exists: %s.%s', Model.modelName, fnName)
+        return null
+      }
+
+      // Don't add the remote method if it already exists on the model
+      if (hasRemoteMethod(Model, fnNameRemote)) {
+        debug('Remote method already exists: %s.%s', Model.modelName, fnName)
+        return null
+      }
 
       debug('Create remote method for %s.%s', Model.modelName, fnName)
 
@@ -62,6 +87,7 @@ function addRemoteMethods(app) {
         ctx.res.setHeader('Content-Type', 'text/plain')
         return ctx.res.end(ctx.result)
       })
+      return true
     })
   })
 }


### PR DESCRIPTION
There was a bug in this component that created duplicate methods and remote methods on an inherited model instance, for instance `user` that has a baseModel `User`.

This in turn caused the `loopback-sdk-builder` to create duplicate references to these methods. 

While this is something that should also be addressed in `loopback-sdk-builder`, this method should not recreate (remote) methods that already exist. 

@mrfelton can you please review?